### PR TITLE
fix: provide port base url as default and correct test action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,6 @@ jobs:
           type: 'jira'
           port_client_id: ${{ secrets.PORT_CLIENT_ID }}
           port_client_secret: ${{ secrets.PORT_CLIENT_SECRET }}
-          port_base_url: https://app.getport.io
           config: |
             jira_host: ${{ secrets.JIRA_HOST }}
             atlassian_user_email: ${{ secrets.JIRA_USER_EMAIL }}

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,7 @@ inputs:
     required: true
   port_base_url:
     description: 'The Port base URL'
+    default: 'https://api.getport.io'
     required: false
   initialize_port_resources:
     description: 'Should Ocean try to create the default resources (blueprints, pages, integration config, etc.) provided with the integration'


### PR DESCRIPTION
Our integrations were broken because:
- A required parameter was added for the integration to work on the backend, but wasn't set as required in the GitHub action inputs:
`pydantic.error_wrappers.ValidationError: 1 validation error for IntegrationConfiguration
port -> base_url`

- The required parameter in the docs `https://app.getport.io` should be `https://api.getport.io`

I left it as a default to `https://api.getport.io` which makes sense to me but of course feel free to change. Adding an extra input for the API URL seems like it's not needed for the user if it's the same for everything.
